### PR TITLE
added running time and memory usage

### DIFF
--- a/controllers/submitcode.js
+++ b/controllers/submitcode.js
@@ -68,6 +68,8 @@ const handleSubmitCode = (fs, submitRecord) => (req, resp) => {
                                             result.stdout = removeTrailing(result.stdout);
                                             outputData = removeTrailing(outputData);     
                                             inputData = removeTrailing(inputData);
+                                            runningTime = result.cpuUsage;
+                                            memoryUsage = result.memoryUsage;  
 
                                             let isAccepted = "WA";
                                             if (result.exitCode === null || result.exitCode === 143) {
@@ -99,6 +101,8 @@ const handleSubmitCode = (fs, submitRecord) => (req, resp) => {
                                                 input: inputData,
                                                 expectedOutput: outputData,
                                                 programOutput: result,
+                                                runningTime: runningTime,
+                                                memoryUsage: memoryUsage,
                                                 isAccepted: isAccepted
                                             });
                                             resolve(i);
@@ -118,6 +122,8 @@ const handleSubmitCode = (fs, submitRecord) => (req, resp) => {
                                                 result.stdout = removeTrailing(result.stdout);
                                                 outputData = removeTrailing(outputData);     
                                                 inputData = removeTrailing(inputData);
+                                                runningTime = result.cpuUsage;
+                                                memoryUsage = result.memoryUsage;
 
                                                 let isAccepted = "WA";
                                                 if (result.exitCode === null || result.exitCode === 143) {
@@ -152,6 +158,8 @@ const handleSubmitCode = (fs, submitRecord) => (req, resp) => {
                                                     input: inputData,
                                                     expectedOutput: outputData,
                                                     programOutput: result,
+                                                    runningTime: runningTime,
+                                                    memoryUsage: memoryUsage,
                                                     isAccepted: isAccepted
                                                 });
                                                 resolve(i);


### PR DESCRIPTION
I thought it'd be helpful to know whether the code runs within the time and memory constraint or not, hence the running time and memory usage addition. It came with the compile-run library in the first place, so there's not much modifications.  But, the documentation stated that the running time and memory usage is not guaranteed to be accurate. Still, I think it might be a good estimate nonetheless. 
The test results now show status (as before), running time in seconds, and memory usage (in KB or MB, depending on the size, changes automatically). 